### PR TITLE
Fix highlighting when a class/enum/struct conforms to multiple protocols

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -112,7 +112,7 @@ syntax keyword swiftStructure
       \ struct
       \ enum
 
-syntax region swiftTypeWrapper start="\v:\s*" end="\v[^\w]" contains=swiftString,swiftType,swiftGenericsWrapper transparent oneline
+syntax region swiftTypeWrapper start="\v:\s*" end="\v(,\s?\w+\s?\{)|[^\w]" contains=swiftString,swiftType,swiftGenericsWrapper transparent oneline
 syntax region swiftGenericsWrapper start="\v\<" end="\v\>" contains=swiftType transparent oneline
 syntax region swiftLiteralWrapper start="\v\=\s*" end="\v(\[\]|\(\))" contains=swiftType transparent oneline
 syntax region swiftReturnWrapper start="\v-\>\s*" end="\v(\{|$)" contains=swiftType transparent oneline


### PR DESCRIPTION
I just modified the "swiftType" match to include an optional comma plus another type.